### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ For run you need docker - ***https://docs.docker.com/engine/install/ubuntu/***
 
 1. Clone repo by ```git clone https://github.com/nlemeshko/SimSWAP-docker.git```
 2. cd SimSWAP-docker
-3. docker build . --tag simswap 
-4. docker run simswap
+3. docker build . --tag mdsn/simswap
+4. docker run mdsn/simswap
 5. Upload image and video file to source path
 6. Run - ```bash start.sh``` and type name of files
 7. Check output in source path


### PR DESCRIPTION
In the building instructions you are naming the image "simswap", but in start.sh it's called with `docker run mdsn/simswap`... 
Since the two names don't match docker will download again an entire 10 Gb image!
Also, may I ask what's the reason for running the image right after building it? (point #4 in README.md)